### PR TITLE
Storage Class "manual" to "default" 

### DIFF
--- a/deploy/mariadb_pv.yaml
+++ b/deploy/mariadb_pv.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     type: local
 spec:
-  storageClassName: manual
+  storageClassName: default
   capacity:
     storage: 1Gi
   accessModes:

--- a/deploy/mariadb_pvc.yaml
+++ b/deploy/mariadb_pvc.yaml
@@ -3,7 +3,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: mariadb-pv-claim
 spec:
-  storageClassName: manual
+  storageClassName: default
   accessModes:
     - ReadWriteOnce
   resources:


### PR DESCRIPTION
Hi  Abhijit, 
I just changed the Storage Class "manual" to "default"  in mariadb-operator/deploy/mariadb_pvc.yaml and mariadb-operator/deploy/mariadb_pv.yaml ., please approve. 

I have created an issue as well for this. Please have a look at https://github.com/abalki001/mariadb-operator/issues/9

Regards:
Ghanshyam S.